### PR TITLE
Account select

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,7 +1,6 @@
 ---
 cluster:
   - "owens"
-  - "owens-slurm"
 form:
   - version
   - bc_account

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,9 +1,14 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
 ---
 cluster:
   - "owens"
 form:
   - version
-  - bc_account
+  - account
   - bc_num_hours
   - bc_num_slots
   - num_cores
@@ -25,9 +30,13 @@ attributes:
   bc_num_slots: "1"
   bc_vnc_resolution:
     required: true
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   node_type:
     widget: select
     label: "Node type"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -17,6 +17,7 @@
 batch_connect:
   template: vnc
 script:
+  accounting_id: "<%= account %>"
   native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,20 +1,16 @@
 <%-
   ppn = num_cores.blank? ? 28 : num_cores.to_i
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
 
   case node_type
   when "hugemem"
     ppn = 48
     partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
     slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--partition", partition ]
-    torque_args = "#{nodes}:ppn=#{ppn}:#{node_type}"
   when "vis"
     slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1", "--gres", "vis" ]
-    torque_args = "#{nodes}:ppn=#{ppn}:#{node_type}:gpus=1"
   else
     slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}" ]
-    torque_args = "#{nodes}:ppn=#{ppn}"
   end
 %>
 ---
@@ -22,11 +18,6 @@ batch_connect:
   template: vnc
 script:
   native:
-  <%- if torque_cluster %>
-    resources:
-      nodes: "<%= torque_args %>"
-  <%- else %>
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-  <%- end %>
   <%- end %>


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.

It also removes all the now vestigial torque items.