### PR TITLE
Enable using hugemem partial nodes

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -88,9 +88,9 @@ attributes:
           ]
         - [
             "hugemem", "hugemem",
-            data-min-num-cores-for-cluster-owens: 48,
+            data-min-num-cores-for-cluster-owens: 4,
             data-max-num-cores-for-cluster-owens: 48,
-            data-min-num-cores-for-cluster-pitzer: 80,
+            data-min-num-cores-for-cluster-pitzer: 4,
             data-max-num-cores-for-cluster-pitzer: 80,
           ]
         - [

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -4,7 +4,6 @@
 
   case node_type
   when "hugemem"
-    ppn = 48
     partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
     slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--partition", partition ]
   when "vis"


### PR DESCRIPTION
I noticed in [another pr](https://github.com/OSC/bc_osc_comsol/pull/18/files#diff-6d5a7b8c0520beea1e09043e8940bd15e357824f8fbdee8216290425dbf94142) we set `min-num-cores` to 4, should this be the case for all hugemem or can we just remove this field?