### PR TITLE
fix gpu/vis mixup and add 40core machines back

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -71,9 +71,19 @@ attributes:
             data-option-for-cluster-owens: false,
           ]
         - [
+            "40 core",     "any-40core",
+            data-max-num-cores-for-cluster-pitzer: 40,
+            data-option-for-cluster-owens: false,
+          ]
+        - [
             "any gpu",     "gpu",
             data-max-num-cores-for-cluster-owens: 28,
             data-max-num-cores-for-cluster-pitzer: 48,
+          ]
+        - [
+            "40 core gpu",     "gpu-40core",
+          data-max-num-cores-for-cluster-pitzer: 40,
+          data-option-for-cluster-owens: false,
           ]
         - [
             "48 core gpu",     "gpu-48core",

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,15 +1,40 @@
 <%-
-  ppn = num_cores.blank? ? 28 : num_cores.to_i
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
+
+  cores_lookup = {
+      "hugemem" => {"pitzer" => "80", "owens" => "48"},
+      "largemem" => {"pitzer" => "48", "owens" => "28"},
+
+      "any" => {"pitzer" => "40", "owens" => "28"},
+      "gpu" => {"pitzer" => "48", "owens" => "28"},
+
+      "any-48core" => {"pitzer" => "48", "owens" => "28"},
+      "gpu-48core" => {"pitzer" => "48", "owens" => "28"},
+
+      "any-40core" => {"pitzer" => "40", "owens" => "28"},
+      "gpu-40core" => {"pitzer" => "40", "owens" => "28"},
+  }
+
+  max_cores = cores_lookup[node_type][cluster]
+  ppn = num_cores.blank? ? max_cores : num_cores.to_i
+
 
   case node_type
   when "hugemem"
     partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
     slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--partition", partition ]
-  when "vis"
-    slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1", "--gres", "vis" ]
+  when "gpu"
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1" ]
+  when "any40-core"
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--contstraint", "48core" ]
+  when "any48-core"
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--contstraint", "48core" ]
+  when "gpu-48core"
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1", "--constraint", "48core" ]
+  when "gpu-40core"
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1", "--constraint", "40core" ]
   else
-    slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}" ]
+    slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}" ]
   end
 %>
 ---


### PR DESCRIPTION
fix gpu/vis mixup and add 40core machines back.

Somehow we broke support for `vis` nodes, so this adds regular GPU requests back into the mix and removes `vis` option.